### PR TITLE
fix: typing on tags should be map not object

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -103,5 +103,5 @@ variable "max_session_duration" {
 variable "tags" {
   default     = {}
   description = "Map of tags to be applied to all resources."
-  type        = object({})
+  type        = map(string)
 }


### PR DESCRIPTION
This changes the typing declaration on `var.tags` to ensure tags can be properly passed in. When defined as `object({})` the input tag contents seem to be ignored as is evident by this truncated plan:

```hcl
  # aws_iam_openid_connect_provider.github[0] will be created
  + resource "aws_iam_openid_connect_provider" "github" {
      + arn             = (known after apply)
      + client_id_list  = [
          + "https://github.com/REDACTED",
          + "sts.amazonaws.com",
        ]
      + id              = (known after apply)
      + tags_all        = (known after apply)
      + thumbprint_list = [
          + "6938fd4d98bab03faadb97b34396831e3780aea1",
        ]
      + url             = "https://token.actions.githubusercontent.com"
    }
```

When changed there as in this PR, there is a `tag` attribute with the expected contents.