### PR TITLE
feat: add support for creating multiple roles

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,10 +6,6 @@ without requiring long-lived credentials to be stored as GitHub secrets.
 
 ## 🔨 Getting started
 
-### Requirements
-
-* [Terraform] 1.0+
-
 ### Installation and usage
 
 Refer to the [complete example] to view all the available configuration options.
@@ -53,39 +49,64 @@ jobs:
     - run: aws sts get-caller-identity
 ```
 
-### Inputs
+<!-- BEGIN_TF_DOCS -->
+## Requirements
 
-#### Required
+| Name | Version |
+|------|---------|
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | ~> 1.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 4.0 |
 
-| Name                  | Type           | Description                      |
-|-----------------------|----------------|----------------------------------|
-| `github_organisation` | `string`       | GitHub organisation name.        |
-| `github_repositories` | `list(string)` | List of GitHub repository names. |
+## Providers
 
-#### Optional
+| Name | Version |
+|------|---------|
+| <a name="provider_aws"></a> [aws](#provider\_aws) | ~> 4.0 |
 
-| Name                            | Default       | Description                                             |
-|---------------------------------|---------------|---------------------------------------------------------|
-| `attach_admin_policy`           | `false`       | Flag to attach/detach the AdministratorAccess policy.   |
-| `attach_read_only_policy`       | `true`        | Flag to attach/detach the ReadOnly policy.              |
-| `enabled`                       | `true`        | Flag to enable/disable creation of resources.           |
-| `force_detach_policies`         | `false`       | Flag to force detach policies attached to the IAM role. |
-| `github_thumbprint`             | `"6938fd4d…"` | GitHub OpenID TLS certificate thumbprint.               |
-| `iam_policy_name`               | `"github"`    | Name of the IAM policy to be assumed by GitHub.         |
-| `iam_policy_path`               | `"/"`         | Path to the IAM policy.                                 |
-| `iam_role_name`                 | `"github"`    | Name of the IAM role.                                   |
-| `iam_role_path`                 | `"/"`         | Path to the IAM role.                                   |
-| `iam_role_permissions_boundary` | `""`          | Permissions boundary to be used by the IAM role.        |
-| `iam_role_policy_arns`          | `[]`          | List of IAM policy ARNs to be attached to the IAM role. |
-| `managed_policy_arns`           | `[]`          | List of managed policy ARNs to apply to the IAM role.   |
-| `max_session_duration`          | `3600`        | Maximum session duration in seconds.                    |
-| `tags`                          | `{}`          | Map of tags to be applied to all resources.             |
+## Modules
 
-### Outputs
+No modules.
 
-| Name           | Type     | Description          |
-|----------------|----------|----------------------|
-| `iam_role_arn` | `string` | ARN of the IAM role. |
+## Resources
+
+| Name | Type |
+|------|------|
+| [aws_iam_openid_connect_provider.github](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_openid_connect_provider) | resource |
+| [aws_iam_role.github](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
+| [aws_iam_role_policy_attachment.admin](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
+| [aws_iam_role_policy_attachment.custom](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
+| [aws_iam_role_policy_attachment.read_only](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
+| [aws_iam_openid_connect_provider.github](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_openid_connect_provider) | data source |
+| [aws_iam_policy_document.assume_role](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
+| [aws_partition.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/partition) | data source |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_attach_admin_policy"></a> [attach\_admin\_policy](#input\_attach\_admin\_policy) | Flag to enable/disable the attachment of the AdministratorAccess policy. | `bool` | `false` | no |
+| <a name="input_attach_read_only_policy"></a> [attach\_read\_only\_policy](#input\_attach\_read\_only\_policy) | Flag to enable/disable the attachment of the ReadOnly policy. | `bool` | `true` | no |
+| <a name="input_create_oidc_provider"></a> [create\_oidc\_provider](#input\_create\_oidc\_provider) | Flag to enable/disable the creation of the GitHub OIDC provider. | `bool` | `true` | no |
+| <a name="input_enabled"></a> [enabled](#input\_enabled) | Flag to enable/disable the creation of resources. | `bool` | `true` | no |
+| <a name="input_force_detach_policies"></a> [force\_detach\_policies](#input\_force\_detach\_policies) | Flag to force detachment of policies attached to the IAM role. | `string` | `false` | no |
+| <a name="input_github_organisation"></a> [github\_organisation](#input\_github\_organisation) | GitHub organisation name. | `string` | n/a | yes |
+| <a name="input_github_repositories"></a> [github\_repositories](#input\_github\_repositories) | List of GitHub repository names. | `list(string)` | n/a | yes |
+| <a name="input_github_thumbprint"></a> [github\_thumbprint](#input\_github\_thumbprint) | GitHub OpenID TLS certificate thumbprint. | `string` | `"6938fd4d98bab03faadb97b34396831e3780aea1"` | no |
+| <a name="input_iam_policy_name"></a> [iam\_policy\_name](#input\_iam\_policy\_name) | Name of the IAM policy to be assumed by GitHub. | `string` | `"github"` | no |
+| <a name="input_iam_policy_path"></a> [iam\_policy\_path](#input\_iam\_policy\_path) | Path to the IAM policy. | `string` | `"/"` | no |
+| <a name="input_iam_role_name"></a> [iam\_role\_name](#input\_iam\_role\_name) | Name of the IAM role. | `string` | `"github"` | no |
+| <a name="input_iam_role_path"></a> [iam\_role\_path](#input\_iam\_role\_path) | Path to the IAM role. | `string` | `"/"` | no |
+| <a name="input_iam_role_permissions_boundary"></a> [iam\_role\_permissions\_boundary](#input\_iam\_role\_permissions\_boundary) | ARN of the permissions boundary to be used by the IAM role. | `string` | `""` | no |
+| <a name="input_iam_role_policy_arns"></a> [iam\_role\_policy\_arns](#input\_iam\_role\_policy\_arns) | List of IAM policy ARNs to attach to the IAM role. | `list(string)` | `[]` | no |
+| <a name="input_max_session_duration"></a> [max\_session\_duration](#input\_max\_session\_duration) | Maximum session duration in seconds. | `number` | `3600` | no |
+| <a name="input_tags"></a> [tags](#input\_tags) | Map of tags to be applied to all resources. | `map(string)` | `{}` | no |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| <a name="output_iam_role_arn"></a> [iam\_role\_arn](#output\_iam\_role\_arn) | ARN of the IAM role. |
+<!-- END_TF_DOCS -->
 
 ## References
 

--- a/data.tf
+++ b/data.tf
@@ -28,10 +28,16 @@ data "aws_iam_policy_document" "assume_role" {
     }
 
     principals {
-      identifiers = [aws_iam_openid_connect_provider.github[0].arn]
+      identifiers = [local.oidc_provider.arn]
       type        = "Federated"
     }
   }
 
   version = "2012-10-17"
+}
+
+data "aws_iam_openid_connect_provider" "github" {
+  count = var.enabled && !var.create_oidc_provider ? 1 : 0
+
+  url = "https://token.actions.githubusercontent.com"
 }

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -9,6 +9,7 @@ module "aws_oidc_github" {
 
   attach_admin_policy           = var.attach_admin_policy
   attach_read_only_policy       = var.attach_read_only_policy
+  create_oidc_provider          = var.create_oidc_provider
   force_detach_policies         = var.force_detach_policies
   github_thumbprint             = var.github_thumbprint
   iam_policy_name               = var.iam_policy_name

--- a/examples/complete/variables.tf
+++ b/examples/complete/variables.tf
@@ -10,6 +10,12 @@ variable "attach_read_only_policy" {
   type        = bool
 }
 
+variable "create_oidc_provider" {
+  default     = true
+  description = "Flag to enable/disable the creation of the GitHub OIDC provider."
+  type        = bool
+}
+
 variable "enabled" {
   default     = true
   description = "Flag to enable/disable the creation of resources."

--- a/examples/complete/versions.tf
+++ b/examples/complete/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 3.70"
+      version = "~> 4.0"
     }
   }
 

--- a/main.tf
+++ b/main.tf
@@ -14,6 +14,8 @@
 
 locals {
   partition = data.aws_partition.current.partition
+
+  oidc_provider = var.create_oidc_provider ? aws_iam_openid_connect_provider.github[0] : data.aws_iam_openid_connect_provider.github[0]
 }
 
 resource "aws_iam_role" "github" {
@@ -51,7 +53,7 @@ resource "aws_iam_role_policy_attachment" "custom" {
 }
 
 resource "aws_iam_openid_connect_provider" "github" {
-  count = var.enabled ? 1 : 0
+  count = var.enabled && var.create_oidc_provider ? 1 : 0
 
   client_id_list  = ["https://github.com/${var.github_organisation}", "sts.amazonaws.com"]
   tags            = var.tags

--- a/variables.tf
+++ b/variables.tf
@@ -24,6 +24,12 @@ variable "attach_read_only_policy" {
   type        = bool
 }
 
+variable "create_oidc_provider" {
+  default     = true
+  description = "Flag to enable/disable the creation of the GitHub OIDC provider."
+  type        = bool
+}
+
 variable "enabled" {
   default     = true
   description = "Flag to enable/disable the creation of resources."

--- a/versions.tf
+++ b/versions.tf
@@ -16,7 +16,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 3.70"
+      version = "~> 4.0"
     }
   }
 


### PR DESCRIPTION
This adds the ability to support the creation of multiple roles to this
module. Due to the fact that you can only have one OIDC provider per
URL, this module fails with a 409 error, like the below:

```
Error: error creating IAM OIDC Provider: EntityAlreadyExists: Provider
with url https://token.actions.githubusercontent.com already exists.
```

This feature is desired in the potential scenario where one wants to
create separate plan and apply roles in the same account.

To address this, we add an input variable to control whether we create
a `aws_iam_openid_connect_provider` resource or reference an existing
one using a data source. This data source was added in the AWS provider
version `4.0`, so this also includes changing the provider requirements
to that version.

Finally, this changes the README to include generated docs from
`terraform-docs` as that seemed like the easiest method to update
them. I hope this is acceptable.