### PR TITLE
rm unused variables, upd variable documentation.rename organisation -> organization

### DIFF
--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -12,8 +12,6 @@ module "aws_oidc_github" {
   create_oidc_provider          = var.create_oidc_provider
   force_detach_policies         = var.force_detach_policies
   github_thumbprint             = var.github_thumbprint
-  iam_policy_name               = var.iam_policy_name
-  iam_policy_path               = var.iam_policy_path
   iam_role_name                 = var.iam_role_name
   iam_role_path                 = var.iam_role_path
   iam_role_permissions_boundary = var.iam_role_permissions_boundary

--- a/examples/complete/variables.tf
+++ b/examples/complete/variables.tf
@@ -44,18 +44,6 @@ variable "github_thumbprint" {
   type        = string
 }
 
-variable "iam_policy_name" {
-  default     = "github"
-  description = "Name of the IAM policy to be assumed by GitHub."
-  type        = string
-}
-
-variable "iam_policy_path" {
-  default     = "/"
-  description = "Path to the IAM policy."
-  type        = string
-}
-
 variable "iam_role_name" {
   default     = "github"
   description = "Name of the IAM role."

--- a/variables.tf
+++ b/variables.tf
@@ -42,13 +42,13 @@ variable "force_detach_policies" {
   type        = string
 }
 
-variable "github_organisation" {
-  description = "GitHub organisation name."
+variable "github_organization" {
+  description = "GitHub organization name."
   type        = string
 }
 
 variable "github_repositories" {
-  description = "List of GitHub repository names."
+  description = "List of GitHub repository names which will be authorized to assume role."
   type        = list(string)
 }
 
@@ -59,27 +59,15 @@ variable "github_thumbprint" {
   type        = string
 }
 
-variable "iam_policy_name" {
-  default     = "github"
-  description = "Name of the IAM policy to be assumed by GitHub."
-  type        = string
-}
-
-variable "iam_policy_path" {
-  default     = "/"
-  description = "Path to the IAM policy."
-  type        = string
-}
-
 variable "iam_role_name" {
   default     = "github"
-  description = "Name of the IAM role."
+  description = "Name of the IAM role to be created. This will be assumable by GitHub."
   type        = string
 }
 
 variable "iam_role_path" {
   default     = "/"
-  description = "Path to the IAM role."
+  description = "Path under which to create IAM role."
   type        = string
 }
 


### PR DESCRIPTION
Not trying to start a naming war over UK vs US spellings, but based on [GitHub's API ](https://docs.github.com/en/rest/reference/orgs) docs I feel a Z is more appropriate.