### PR TITLE
Changed local.oidc_provider local.oidc_provider_arn

### DIFF
--- a/data.tf
+++ b/data.tf
@@ -28,7 +28,7 @@ data "aws_iam_policy_document" "assume_role" {
     }
 
     principals {
-      identifiers = [local.oidc_provider.arn]
+      identifiers = [local.oidc_provider_arn]
       type        = "Federated"
     }
   }

--- a/main.tf
+++ b/main.tf
@@ -14,7 +14,7 @@
 
 locals {
   github_organizations = [for repo in var.github_repositories : split("/", repo)[0]]
-  oidc_provider        = var.create_oidc_provider ? aws_iam_openid_connect_provider.github[0] : data.aws_iam_openid_connect_provider.github[0]
+  oidc_provider_arn    = var.create_oidc_provider ? aws_iam_openid_connect_provider.github[0].arn : data.aws_iam_openid_connect_provider.github[0].arn
   partition            = data.aws_partition.current.partition
 }
 


### PR DESCRIPTION
A fix to following error...

Terraform v1.1.0
on linux_arm64
+ provider registry.terraform.io/hashicorp/aws v4.8.0

│ Error: Inconsistent conditional result types
│ 
│   on .terraform/modules/oidc-github/main.tf line 17, in locals:
│   17:   oidc_provider        = var.create_oidc_provider ? aws_iam_openid_connect_provider.github[0] : data.aws_iam_openid_connect_provider.github[0]
│     ├────────────────
│     │ aws_iam_openid_connect_provider.github[0] is a object, known only after apply
│     │ data.aws_iam_openid_connect_provider.github[0] is a object, known only after apply
│     │ var.create_oidc_provider is a bool, known only after apply
│ 
│ The true and false result expressions must have consistent types. The given expressions are object and object, respectively.
