### PR TITLE
feat: allow every repo on the organization

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -51,7 +51,7 @@ variable "github_repositories" {
     // organization/repository format used by GitHub.
     condition = length([
       for repo in var.github_repositories : 1
-      if length(regexall("^[A-Za-z0-9_.-]+?/([A-Za-z0-9_.-]+|\*)$", repo)) > 0
+      if length(regexall("^[A-Za-z0-9_.-]+?/([A-Za-z0-9_.-]+|\\*)$", repo)) > 0
     ]) == length(var.github_repositories)
     error_message = "Repositories must be specified in the organization/repository format."
   }

--- a/variables.tf
+++ b/variables.tf
@@ -51,7 +51,7 @@ variable "github_repositories" {
     // organization/repository format used by GitHub.
     condition = length([
       for repo in var.github_repositories : 1
-      if length(regexall("^[A-Za-z0-9_.-]+?/[A-Za-z0-9_.-]+$", repo)) > 0
+      if length(regexall("^[A-Za-z0-9_.-]+?/([A-Za-z0-9_.-]+|\*)$", repo)) > 0
     ]) == length(var.github_repositories)
     error_message = "Repositories must be specified in the organization/repository format."
   }


### PR DESCRIPTION
On v0.5.0 this was possible, but the new validation broke the '*' use.