### PR TITLE
Prevent duplicate client_ids records

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 locals {
-  github_organizations = [for repo in var.github_repositories : split("/", repo)[0]]
+  github_organizations = toset([for repo in var.github_repositories : split("/", repo)[0]])
   oidc_provider_arn    = var.enabled ? (var.create_oidc_provider ? aws_iam_openid_connect_provider.github[0].arn : data.aws_iam_openid_connect_provider.github[0].arn) : ""
   partition            = data.aws_partition.current.partition
 }
@@ -64,10 +64,10 @@ resource "aws_iam_role_policy_attachment" "custom" {
 resource "aws_iam_openid_connect_provider" "github" {
   count = var.enabled && var.create_oidc_provider ? 1 : 0
 
-  client_id_list = distinct(concat(
+  client_id_list = concat(
     [for org in local.github_organizations : "https://github.com/${org}"],
     ["sts.amazonaws.com"]
-  ))
+  )
 
   tags            = var.tags
   thumbprint_list = [var.github_thumbprint]

--- a/main.tf
+++ b/main.tf
@@ -64,10 +64,10 @@ resource "aws_iam_role_policy_attachment" "custom" {
 resource "aws_iam_openid_connect_provider" "github" {
   count = var.enabled && var.create_oidc_provider ? 1 : 0
 
-  client_id_list = concat(
+  client_id_list = distinct(concat(
     [for org in local.github_organizations : "https://github.com/${org}"],
     ["sts.amazonaws.com"]
-  )
+  ))
 
   tags            = var.tags
   thumbprint_list = [var.github_thumbprint]


### PR DESCRIPTION
If a user adds a number of repository references from the same Org, the module would add a new client_id record for the org for each repository reference. This resolves that concern by ensuring that the client_ids list always consists of distinct records. 