### PR TITLE
use data source for obtaining thumbprint

### DIFF
--- a/data.tf
+++ b/data.tf
@@ -44,3 +44,7 @@ data "aws_iam_openid_connect_provider" "github" {
 
   url = "https://token.actions.githubusercontent.com"
 }
+
+data "tls_certificate" "github" {
+  url = "https://token.actions.githubusercontent.com/.well-known/openid-configuration"
+}

--- a/main.tf
+++ b/main.tf
@@ -70,6 +70,6 @@ resource "aws_iam_openid_connect_provider" "github" {
   )
 
   tags            = var.tags
-  thumbprint_list = [var.github_thumbprint]
+  thumbprint_list = [data.tls_certificate.github.certificates[0].sha1_fingerprint]
   url             = "https://token.actions.githubusercontent.com"
 }

--- a/variables.tf
+++ b/variables.tf
@@ -57,16 +57,6 @@ variable "github_repositories" {
   }
 }
 
-// Refer to the README for information on obtaining the thumbprint.
-// This is specified as a variable to allow it to be updated quickly if it is
-// unexpectedly changed by GitHub.
-// See: https://github.blog/changelog/2022-01-13-github-actions-update-on-oidc-based-deployments-to-aws/
-variable "github_thumbprint" {
-  default     = "6938fd4d98bab03faadb97b34396831e3780aea1"
-  description = "GitHub OpenID TLS certificate thumbprint."
-  type        = string
-}
-
 variable "iam_role_name" {
   default     = "github"
   description = "Name of the IAM role to be created. This will be assumable by GitHub."


### PR DESCRIPTION
Instead of using variable for setting the certificate thumbprint, we can use data source to obtain the same.