### PR TITLE
TLS provider version 3 plus

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,45 +61,43 @@ jobs:
 ```
 
 <!-- BEGIN_TF_DOCS -->
-
 ## Resources
 
-| Name                                                                                                                                                 | Type        |
-| ---------------------------------------------------------------------------------------------------------------------------------------------------- | ----------- |
-| [aws_iam_openid_connect_provider.github](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_openid_connect_provider)    | resource    |
-| [aws_iam_role.github](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role)                                          | resource    |
-| [aws_iam_role_policy_attachment.admin](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment)       | resource    |
-| [aws_iam_role_policy_attachment.custom](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment)      | resource    |
-| [aws_iam_role_policy_attachment.read_only](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment)   | resource    |
+| Name | Type |
+|------|------|
+| [aws_iam_openid_connect_provider.github](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_openid_connect_provider) | resource |
+| [aws_iam_role.github](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
+| [aws_iam_role_policy_attachment.admin](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
+| [aws_iam_role_policy_attachment.custom](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
+| [aws_iam_role_policy_attachment.read_only](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
 | [aws_iam_openid_connect_provider.github](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_openid_connect_provider) | data source |
-| [aws_iam_policy_document.assume_role](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document)            | data source |
-| [aws_partition.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/partition)                                    | data source |
-| [tls_certificate.github](https://registry.terraform.io/providers/hashicorp/tls/latest/docs/data-sources/certificate)                                 | data source |
+| [aws_iam_policy_document.assume_role](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
+| [aws_partition.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/partition) | data source |
+| [tls_certificate.github](https://registry.terraform.io/providers/hashicorp/tls/latest/docs/data-sources/certificate) | data source |
 
 ## Inputs
 
-| Name                          | Description                                                                 | Type           | Default    | Required |
-| ----------------------------- | --------------------------------------------------------------------------- | -------------- | ---------- | :------: |
-| attach_admin_policy           | Flag to enable/disable the attachment of the AdministratorAccess policy.    | `bool`         | `false`    |    no    |
-| attach_read_only_policy       | Flag to enable/disable the attachment of the ReadOnly policy.               | `bool`         | `true`     |    no    |
-| create_oidc_provider          | Flag to enable/disable the creation of the GitHub OIDC provider.            | `bool`         | `true`     |    no    |
-| enabled                       | Flag to enable/disable the creation of resources.                           | `bool`         | `true`     |    no    |
-| force_detach_policies         | Flag to force detachment of policies attached to the IAM role.              | `bool`         | `false`    |    no    |
-| github_repositories           | List of GitHub organization/repository names authorized to assume the role. | `list(string)` | n/a        |   yes    |
-| iam_role_inline_policies      | Inline policies map with policy name as key and json as value.              | `map(string)`  | `{}`       |    no    |
-| iam_role_name                 | Name of the IAM role to be created. This will be assumable by GitHub.       | `string`       | `"github"` |    no    |
-| iam_role_path                 | Path under which to create IAM role.                                        | `string`       | `"/"`      |    no    |
-| iam_role_permissions_boundary | ARN of the permissions boundary to be used by the IAM role.                 | `string`       | `""`       |    no    |
-| iam_role_policy_arns          | List of IAM policy ARNs to attach to the IAM role.                          | `list(string)` | `[]`       |    no    |
-| max_session_duration          | Maximum session duration in seconds.                                        | `number`       | `3600`     |    no    |
-| tags                          | Map of tags to be applied to all resources.                                 | `map(string)`  | `{}`       |    no    |
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| attach\_admin\_policy | Flag to enable/disable the attachment of the AdministratorAccess policy. | `bool` | `false` | no |
+| attach\_read\_only\_policy | Flag to enable/disable the attachment of the ReadOnly policy. | `bool` | `true` | no |
+| create\_oidc\_provider | Flag to enable/disable the creation of the GitHub OIDC provider. | `bool` | `true` | no |
+| enabled | Flag to enable/disable the creation of resources. | `bool` | `true` | no |
+| force\_detach\_policies | Flag to force detachment of policies attached to the IAM role. | `bool` | `false` | no |
+| github\_repositories | List of GitHub organization/repository names authorized to assume the role. | `list(string)` | n/a | yes |
+| iam\_role\_inline\_policies | Inline policies map with policy name as key and json as value. | `map(string)` | `{}` | no |
+| iam\_role\_name | Name of the IAM role to be created. This will be assumable by GitHub. | `string` | `"github"` | no |
+| iam\_role\_path | Path under which to create IAM role. | `string` | `"/"` | no |
+| iam\_role\_permissions\_boundary | ARN of the permissions boundary to be used by the IAM role. | `string` | `""` | no |
+| iam\_role\_policy\_arns | List of IAM policy ARNs to attach to the IAM role. | `list(string)` | `[]` | no |
+| max\_session\_duration | Maximum session duration in seconds. | `number` | `3600` | no |
+| tags | Map of tags to be applied to all resources. | `map(string)` | `{}` | no |
 
 ## Outputs
 
-| Name         | Description          |
-| ------------ | -------------------- |
-| iam_role_arn | ARN of the IAM role. |
-
+| Name | Description |
+|------|-------------|
+| iam\_role\_arn | ARN of the IAM role. |
 <!-- END_TF_DOCS -->
 
 ## References

--- a/versions.tf
+++ b/versions.tf
@@ -21,7 +21,7 @@ terraform {
 
     tls = {
       source  = "hashicorp/tls"
-      version = "=> 3.0"
+      version = ">= 3.0"
     }
   }
 

--- a/versions.tf
+++ b/versions.tf
@@ -21,7 +21,7 @@ terraform {
 
     tls = {
       source  = "hashicorp/tls"
-      version = "~> 4.0"
+      version = "=> 3.0"
     }
   }
 


### PR DESCRIPTION
Allow `provider[registry.terraform.io/hashicorp/tls] >= 3.0`

## Background
Allow usage of tls provider version 3.x in stacks alongside this module.

Similar changes in eg. [terraform-aws-eks](https://github.com/terraform-aws-modules/terraform-aws-eks): https://github.com/terraform-aws-modules/terraform-aws-eks/pull/2211