### PR TITLE
feat: allow wildcard in repo names

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -51,7 +51,7 @@ variable "github_repositories" {
     // organization/repository format used by GitHub.
     condition = length([
       for repo in var.github_repositories : 1
-      if length(regexall("^[A-Za-z0-9_.-]+?/([A-Za-z0-9_.:/-]+|\\*)$", repo)) > 0
+      if length(regexall("^[A-Za-z0-9_.-]+?/([A-Za-z0-9_.:/-]+[*]?|\\*)$", repo)) > 0
     ]) == length(var.github_repositories)
     error_message = "Repositories must be specified in the organization/repository format."
   }


### PR DESCRIPTION
I would like to use a wildcard in repository names so that I can allow multiple repos for a project without having to update the trust policy each time, i.e.
```            "Condition": {
                "StringLike": {
                    "token.actions.githubusercontent.com:sub": "repo:liamfit/demo-*:*"
                }
            }
```