### PR TITLE
fix: ensure additional_thumbprint validation allows a null value as p…

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -18,7 +18,7 @@ variable "additional_thumbprints" {
   type        = list(string)
 
   validation {
-    condition     = length(var.additional_thumbprints) <= 4
+    condition     = var.additional_thumbprints != null ? length(var.additional_thumbprints) <= 4 : true
     error_message = "Only 4 additional thumbprints can be set, for a maximum of 5 in the OIDC provider."
   }
 }


### PR DESCRIPTION
Fix issue https://github.com/unfunco/terraform-aws-oidc-github/issues/25

Minimal example for this module can't be executed as the validation of `additional_thumbprints` fails as the input (for which the default is null) cannot be null.

This change only applies the validation on thumbprint length if the provided input is non-null, fixing the issue.