### PR TITLE
Change aws provider version constraint to allow v5

### DIFF
--- a/versions.tf
+++ b/versions.tf
@@ -16,7 +16,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 4.0"
+      version = ">= 4.0"
     }
 
     tls = {


### PR DESCRIPTION
After release of aws provider v 5.0.0 this module had to restrictive version constraint preventing us from using it. Ive changed version constraint to less restrictive. Terrafrom plan and terraform apply didnt pick up any changes after update so it seems to me that everything is still backwards compatible.