### PR TITLE
feat: Add support for GitHub Enterprise Cloud

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -37,7 +37,7 @@ jobs:
       run: terraform validate
     strategy:
       matrix:
-        terraform_version: [ 1.0, 1.1, 1.2, 1.3, 1.4 ]
+        terraform_version: [ "1.0", "1.1", "1.2", "1.3", "1.4" ]
 
   caller-identity:
     if: ${{ github.event_name == 'push' }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -28,13 +28,16 @@ jobs:
     - name: Setup Terraform
       uses: hashicorp/setup-terraform@v1
       with:
-        terraform_version: 1.1.2
+        terraform_version: ${{ matrix.terraform_version }}
     - name: Initialise with no backend
       run: terraform init -backend=false
     - name: Check formatting
       run: terraform fmt -check -recursive
     - name: Validate the configuration
       run: terraform validate
+    strategy:
+      matrix:
+        terraform_version: [ 1.0, 1.1, 1.2, 1.3, 1.4, 1.5 ]
 
   caller-identity:
     if: ${{ github.event_name == 'push' }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -37,7 +37,7 @@ jobs:
       run: terraform validate
     strategy:
       matrix:
-        terraform_version: [ 1.0, 1.1, 1.2, 1.3, 1.4, 1.5 ]
+        terraform_version: [ 1.0, 1.1, 1.2, 1.3, 1.4 ]
 
   caller-identity:
     if: ${{ github.event_name == 'push' }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 Notable changes to this project are documented in this changelog.  
 This project adheres to the [semantic versioning] specification.
 
+## [1.5.0] – 2023-06-04
+
+- Add support for organisations using GitHub Enterprise Cloud.
+
 ## [1.4.0] – 2023-06-01
 
 - Update the AWS provider version constraint to allow v5 ([4f6b152](https://github.com/unfunco/terraform-aws-oidc-github/commit/4f6b152447a4caff21204d3e00417ca96b8de154))
@@ -111,4 +115,5 @@ This project adheres to the [semantic versioning] specification.
 [1.3.0]: https://github.com/unfunco/terraform-aws-oidc-github/compare/v1.2.1...v1.3.0
 [1.3.1]: https://github.com/unfunco/terraform-aws-oidc-github/compare/v1.3.0...v1.3.1
 [1.4.0]: https://github.com/unfunco/terraform-aws-oidc-github/compare/v1.3.1...v1.4.0
+[1.5.0]: https://github.com/unfunco/terraform-aws-oidc-github/compare/v1.4.0...v1.5.0
 [semantic versioning]: https://semver.org

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# AWS federation for GitHub Actions
+# OpenID Connect for AWS and GitHub Actions
 
 [![CI](https://github.com/unfunco/terraform-aws-oidc-github/actions/workflows/ci.yaml/badge.svg)](https://github.com/unfunco/terraform-aws-oidc-github/actions/workflows/ci.yaml)
 [![Cron / Verify](https://github.com/unfunco/terraform-aws-oidc-github/actions/workflows/cron.yaml/badge.svg)](https://github.com/unfunco/terraform-aws-oidc-github/actions/workflows/cron.yaml)
@@ -6,8 +6,8 @@
 [![License: Apache 2.0](https://img.shields.io/badge/License-Apache_2.0-purple.svg)](https://opensource.org/licenses/Apache-2.0)
 
 Terraform module to configure GitHub Actions as an IAM OIDC identity provider in
-AWS. This enables GitHub Actions to access resources within an AWS account
-without requiring long-lived credentials to be stored as GitHub secrets.
+AWS. OpenID Connect allows GitHub Actions workflows to access resources in AWS
+without requiring the AWS credentials as to be stored long-lived GitHub secrets.
 
 ## 🔨 Getting started
 
@@ -28,7 +28,7 @@ provider "aws" {
 
 module "oidc_github" {
   source  = "unfunco/oidc-github/aws"
-  version = "1.4.0"
+  version = "1.5.0"
 
   github_repositories = [
     "org/repo",
@@ -56,10 +56,17 @@ jobs:
     - name: Configure AWS credentials
       uses: aws-actions/configure-aws-credentials@v2
       with:
-        aws-region: ${{ secrets.AWS_REGION }}
-        role-to-assume: arn:aws:iam::${{ secrets.AWS_ACCOUNT_ID }}:role/github
+        aws-region: ${{ env.AWS_REGION }}
+        role-to-assume: arn:aws:iam::${{ env.AWS_ACCOUNT_ID }}:role/github
     - run: aws sts get-caller-identity
 ```
+
+#### Enterprise Cloud
+
+Organisations using GitHub Enterprise Cloud can further improve their security
+posture by setting the `enterprise_slug` variable. This configuration ensures
+that the organisation will receive OIDC tokens from a unique URL, after this is
+applied, the JWT will contain an updated `iss` claim.
 
 <!-- BEGIN_TF_DOCS -->
 
@@ -86,6 +93,7 @@ jobs:
 | attach_read_only_policy       | Flag to enable/disable the attachment of the ReadOnly policy.               | `bool`         | `true`     |    no    |
 | create_oidc_provider          | Flag to enable/disable the creation of the GitHub OIDC provider.            | `bool`         | `true`     |    no    |
 | enabled                       | Flag to enable/disable the creation of resources.                           | `bool`         | `true`     |    no    |
+| enterprise_slug               | Enterprise slug for GitHub Enterprise Cloud customers.                      | `string`       | `""`       |    no    |
 | force_detach_policies         | Flag to force detachment of policies attached to the IAM role.              | `bool`         | `false`    |    no    |
 | github_repositories           | List of GitHub organization/repository names authorized to assume the role. | `list(string)` | n/a        |   yes    |
 | iam_role_inline_policies      | Inline policies map with policy name as key and json as value.              | `map(string)`  | `{}`       |    no    |

--- a/data.tf
+++ b/data.tf
@@ -37,7 +37,7 @@ data "aws_iam_policy_document" "assume_role" {
     }
 
     principals {
-      identifiers = [local.oidc_provider_arn]
+      identifiers = ["${local.oidc_provider_arn}%{if var.enterprise_slug != ""}/${var.enterprise_slug}%{endif}"]
       type        = "Federated"
     }
   }
@@ -48,7 +48,7 @@ data "aws_iam_policy_document" "assume_role" {
 data "aws_iam_openid_connect_provider" "github" {
   count = var.enabled && !var.create_oidc_provider ? 1 : 0
 
-  url = "https://token.actions.githubusercontent.com"
+  url = "https://token.actions.githubusercontent.com%{if var.enterprise_slug != ""}/${var.enterprise_slug}%{endif}"
 }
 
 data "tls_certificate" "github" {

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -29,6 +29,7 @@ module "aws_oidc_github" {
 data "aws_iam_policy_document" "example" {
   statement {
     actions   = ["s3:GetObject"]
-    resources = ["*"]
+    effect    = "Allow"
+    resources = ["dynamodb:CreateTable"]
   }
 }

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -7,9 +7,11 @@ module "aws_oidc_github" {
 
   enabled = var.enabled
 
+  additional_thumbprints        = var.additional_thumbprints
   attach_admin_policy           = var.attach_admin_policy
   attach_read_only_policy       = var.attach_read_only_policy
   create_oidc_provider          = var.create_oidc_provider
+  enterprise_slug               = var.enterprise_slug
   force_detach_policies         = var.force_detach_policies
   iam_role_name                 = var.iam_role_name
   iam_role_path                 = var.iam_role_path
@@ -22,8 +24,6 @@ module "aws_oidc_github" {
   iam_role_inline_policies = {
     "example_inline_policy" : data.aws_iam_policy_document.example.json
   }
-
-  additional_thumbprints = var.additional_thumbprints
 }
 
 data "aws_iam_policy_document" "example" {

--- a/examples/complete/variables.tf
+++ b/examples/complete/variables.tf
@@ -33,6 +33,12 @@ variable "enabled" {
   type        = bool
 }
 
+variable "enterprise_slug" {
+  default     = false
+  description = "Enterprise slug for GitHub Enterprise Cloud customers."
+  type        = bool
+}
+
 variable "force_detach_policies" {
   default     = false
   description = "Flag to force detachment of policies attached to the IAM role."

--- a/examples/complete/versions.tf
+++ b/examples/complete/versions.tf
@@ -2,12 +2,12 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 4.0"
+      version = ">= 4.0"
     }
 
     tls = {
       source  = "hashicorp/tls"
-      version = "~> 4.0"
+      version = ">= 3.0"
     }
   }
 

--- a/main.tf
+++ b/main.tf
@@ -70,7 +70,7 @@ resource "aws_iam_openid_connect_provider" "github" {
   )
 
   tags = var.tags
-  url  = "https://token.actions.githubusercontent.com"
+  url  = "https://token.actions.githubusercontent.com%{if var.enterprise_slug != ""}/${var.enterprise_slug}%{endif}"
   thumbprint_list = var.additional_thumbprints != null ? concat(
     [data.tls_certificate.github.certificates[0].sha1_fingerprint],
     [for thumbprint in var.additional_thumbprints : thumbprint]

--- a/variables.tf
+++ b/variables.tf
@@ -47,6 +47,12 @@ variable "enabled" {
   type        = bool
 }
 
+variable "enterprise_slug" {
+  default     = ""
+  description = "Enterprise slug for GitHub Enterprise Cloud customers."
+  type        = string
+}
+
 variable "force_detach_policies" {
   default     = false
   description = "Flag to force detachment of policies attached to the IAM role."


### PR DESCRIPTION
Adds support for GitHub Enterprise Cloud customers by adding a new variable called `enterprise_slug` which when populated, will configure the OIDC provider with a different issuer URL, and will condition the role to be assumed only when the `iss` claim includes the enterprise slug.