### PR TITLE
fix: Reduce the allowed additional_thumbprints

### DIFF
--- a/examples/complete/variables.tf
+++ b/examples/complete/variables.tf
@@ -4,8 +4,8 @@ variable "additional_thumbprints" {
   type        = list(string)
 
   validation {
-    condition     = var.additional_thumbprints == null ? true : length(var.additional_thumbprints) <= 4
-    error_message = "Only 4 additional thumbprints can be set, for a maximum of 5 in the OIDC provider."
+    condition     = var.additional_thumbprints == null ? true : length(var.additional_thumbprints) <= 3
+    error_message = "Only 3 additional thumbprints can be set, for a maximum of 5 in the OIDC provider."
   }
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -18,8 +18,8 @@ variable "additional_thumbprints" {
   type        = list(string)
 
   validation {
-    condition     = var.additional_thumbprints == null ? true : length(var.additional_thumbprints) <= 4
-    error_message = "Only 4 additional thumbprints can be set, for a maximum of 5 in the OIDC provider."
+    condition     = var.additional_thumbprints == null ? true : length(var.additional_thumbprints) <= 3
+    error_message = "Only 3 additional thumbprints can be set, for a maximum of 5 in the OIDC provider."
   }
 }
 


### PR DESCRIPTION
Reduces the number of allowed `additional_thumbprints` from 4 to 3, since GitHub now returns two intermediary thumbprints for the Actions SSL certificate and the maximum number is 5.

Fixes #30 