### PR TITLE
fix: prevent from adding duplicate github thumbprints

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -71,8 +71,10 @@ resource "aws_iam_openid_connect_provider" "github" {
 
   tags = var.tags
   url  = "https://token.actions.githubusercontent.com%{if var.enterprise_slug != ""}/${var.enterprise_slug}%{endif}"
-  thumbprint_list = var.additional_thumbprints != null ? concat(
-    [data.tls_certificate.github.certificates[0].sha1_fingerprint],
-    [for thumbprint in var.additional_thumbprints : thumbprint]
+  thumbprint_list = var.additional_thumbprints != null ? distinct(
+    concat(
+      [data.tls_certificate.github.certificates[0].sha1_fingerprint],
+      [for thumbprint in var.additional_thumbprints : thumbprint]
+    )
   ) : [data.tls_certificate.github.certificates[0].sha1_fingerprint]
 }


### PR DESCRIPTION
I've noticed that when I pass two GitHub thumbprints that are mentioned [here](https://github.blog/changelog/2023-06-27-github-actions-update-on-oidc-integration-with-aws/) . The "autodiscovery" also adds one of them, so I finish with some duplicate thumbprints.
