### PR TITLE
Allow additional audiences

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ applied, the JWT will contain an updated `iss` claim.
 | Name                          | Description                                                                 | Type           | Default                 | Required |
 | ----------------------------- | --------------------------------------------------------------------------- | -------------- | ----------------------- | :------: |
 | additional_thumbprints        | List of additional thumbprints for the OIDC provider.                       | `list(string)` | `null`                  |    no    |
-| allowed_audiences             | List of allowed audiences for the OIDC provider.                            | `list(string)` | `["sts.amazonaws.com"]` |    no    |
+| allowed_audiences             | List of OIDC audiences allowed to assume the role.                          | `list(string)` | `["sts.amazonaws.com"]` |    no    |
 | attach_admin_policy           | Flag to enable/disable the attachment of the AdministratorAccess policy.    | `bool`         | `false`                 |    no    |
 | attach_read_only_policy       | Flag to enable/disable the attachment of the ReadOnly policy.               | `bool`         | `true`                  |    no    |
 | create_oidc_provider          | Flag to enable/disable the creation of the GitHub OIDC provider.            | `bool`         | `true`                  |    no    |

--- a/README.md
+++ b/README.md
@@ -88,23 +88,24 @@ applied, the JWT will contain an updated `iss` claim.
 
 ## Inputs
 
-| Name                          | Description                                                                 | Type           | Default    | Required |
-| ----------------------------- | --------------------------------------------------------------------------- | -------------- | ---------- | :------: |
-| additional_thumbprints        | List of additional thumbprints for the OIDC provider.                       | `list(string)` | `null`     |    no    |
-| attach_admin_policy           | Flag to enable/disable the attachment of the AdministratorAccess policy.    | `bool`         | `false`    |    no    |
-| attach_read_only_policy       | Flag to enable/disable the attachment of the ReadOnly policy.               | `bool`         | `true`     |    no    |
-| create_oidc_provider          | Flag to enable/disable the creation of the GitHub OIDC provider.            | `bool`         | `true`     |    no    |
-| enabled                       | Flag to enable/disable the creation of resources.                           | `bool`         | `true`     |    no    |
-| enterprise_slug               | Enterprise slug for GitHub Enterprise Cloud customers.                      | `string`       | `""`       |    no    |
-| force_detach_policies         | Flag to force detachment of policies attached to the IAM role.              | `bool`         | `false`    |    no    |
-| github_repositories           | List of GitHub organization/repository names authorized to assume the role. | `list(string)` | n/a        |   yes    |
-| iam_role_inline_policies      | Inline policies map with policy name as key and json as value.              | `map(string)`  | `{}`       |    no    |
-| iam_role_name                 | Name of the IAM role to be created. This will be assumable by GitHub.       | `string`       | `"github"` |    no    |
-| iam_role_path                 | Path under which to create IAM role.                                        | `string`       | `"/"`      |    no    |
-| iam_role_permissions_boundary | ARN of the permissions boundary to be used by the IAM role.                 | `string`       | `""`       |    no    |
-| iam_role_policy_arns          | List of IAM policy ARNs to attach to the IAM role.                          | `list(string)` | `[]`       |    no    |
-| max_session_duration          | Maximum session duration in seconds.                                        | `number`       | `3600`     |    no    |
-| tags                          | Map of tags to be applied to all resources.                                 | `map(string)`  | `{}`       |    no    |
+| Name                          | Description                                                                 | Type           | Default                 | Required |
+| ----------------------------- | --------------------------------------------------------------------------- | -------------- | ----------------------- | :------: |
+| additional_thumbprints        | List of additional thumbprints for the OIDC provider.                       | `list(string)` | `null`                  |    no    |
+| allowed_audiences             | List of allowed audiences for the OIDC provider.                            | `list(string)` | `["sts.amazonaws.com"]` |    no    |
+| attach_admin_policy           | Flag to enable/disable the attachment of the AdministratorAccess policy.    | `bool`         | `false`                 |    no    |
+| attach_read_only_policy       | Flag to enable/disable the attachment of the ReadOnly policy.               | `bool`         | `true`                  |    no    |
+| create_oidc_provider          | Flag to enable/disable the creation of the GitHub OIDC provider.            | `bool`         | `true`                  |    no    |
+| enabled                       | Flag to enable/disable the creation of resources.                           | `bool`         | `true`                  |    no    |
+| enterprise_slug               | Enterprise slug for GitHub Enterprise Cloud customers.                      | `string`       | `""`                    |    no    |
+| force_detach_policies         | Flag to force detachment of policies attached to the IAM role.              | `bool`         | `false`                 |    no    |
+| github_repositories           | List of GitHub organization/repository names authorized to assume the role. | `list(string)` | n/a                     |   yes    |
+| iam_role_inline_policies      | Inline policies map with policy name as key and json as value.              | `map(string)`  | `{}`                    |    no    |
+| iam_role_name                 | Name of the IAM role to be created. This will be assumable by GitHub.       | `string`       | `"github"`              |    no    |
+| iam_role_path                 | Path under which to create IAM role.                                        | `string`       | `"/"`                   |    no    |
+| iam_role_permissions_boundary | ARN of the permissions boundary to be used by the IAM role.                 | `string`       | `""`                    |    no    |
+| iam_role_policy_arns          | List of IAM policy ARNs to attach to the IAM role.                          | `list(string)` | `[]`                    |    no    |
+| max_session_duration          | Maximum session duration in seconds.                                        | `number`       | `3600`                  |    no    |
+| tags                          | Map of tags to be applied to all resources.                                 | `map(string)`  | `{}`                    |    no    |
 
 ## Outputs
 

--- a/data.tf
+++ b/data.tf
@@ -32,7 +32,7 @@ data "aws_iam_policy_document" "assume_role" {
 
     condition {
       test     = "StringEquals"
-      values   = ["sts.amazonaws.com"]
+      values   = var.allowed_audiences
       variable = "token.actions.githubusercontent.com:aud"
     }
 

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -8,6 +8,7 @@ module "aws_oidc_github" {
   enabled = var.enabled
 
   additional_thumbprints        = var.additional_thumbprints
+  allowed_audiences             = var.allowed_audiences
   attach_admin_policy           = var.attach_admin_policy
   attach_read_only_policy       = var.attach_read_only_policy
   create_oidc_provider          = var.create_oidc_provider

--- a/examples/complete/variables.tf
+++ b/examples/complete/variables.tf
@@ -9,6 +9,12 @@ variable "additional_thumbprints" {
   }
 }
 
+variable "allowed_audiences" {
+  default     = ["sts.amazonaws.com"]
+  description = "List of allowed audiences for the OIDC provider."
+  type        = list(string)
+}
+
 variable "attach_admin_policy" {
   default     = false
   description = "Flag to enable/disable the attachment of the AdministratorAccess policy."

--- a/examples/complete/variables.tf
+++ b/examples/complete/variables.tf
@@ -11,7 +11,7 @@ variable "additional_thumbprints" {
 
 variable "allowed_audiences" {
   default     = ["sts.amazonaws.com"]
-  description = "List of allowed audiences for the OIDC provider."
+  description = "List of OIDC audiences allowed to assume the role."
   type        = list(string)
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -25,7 +25,7 @@ variable "additional_thumbprints" {
 
 variable "allowed_audiences" {
   default     = ["sts.amazonaws.com"]
-  description = "List of allowed audiences for the OIDC provider."
+  description = "List of OIDC audiences allowed to assume the role."
   type        = list(string)
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -23,6 +23,12 @@ variable "additional_thumbprints" {
   }
 }
 
+variable "allowed_audiences" {
+  default     = ["sts.amazonaws.com"]
+  description = "List of allowed audiences for the OIDC provider."
+  type        = list(string)
+}
+
 variable "attach_admin_policy" {
   default     = false
   description = "Flag to enable/disable the attachment of the AdministratorAccess policy."


### PR DESCRIPTION
I recently fixed an authentication issue by adding "https://github.com/<organization" as an allowed audience in the github IAM trust relation, but I could not persist the change in terraform using this module.

This change adds the ability to specify `allowed_audiences = ["sts.amazonaws.com", "<another_audience>", ...]` with the default value being `["sts.amazonaws.com"]`.