### PR TITLE
Added role name to the outputs

### DIFF
--- a/outputs.tf
+++ b/outputs.tf
@@ -17,3 +17,9 @@ output "iam_role_arn" {
   description = "ARN of the IAM role."
   value       = var.enabled ? aws_iam_role.github[0].arn : ""
 }
+
+output "iam_role_name" {
+  depends_on  = [aws_iam_role.github]
+  description = "Name of the IAM role."
+  value       = var.enabled ? aws_iam_role.github[0].name : ""
+}


### PR DESCRIPTION
Proposed fix for the [output role_arn is incompatible with aws_iam_role_policy_attachment resource](https://github.com/unfunco/terraform-aws-oidc-github/issues/36) issue