### PR TITLE
Add the ARN of the OIDC provider as output

### DIFF
--- a/outputs.tf
+++ b/outputs.tf
@@ -23,3 +23,9 @@ output "iam_role_name" {
   description = "Name of the IAM role."
   value       = var.enabled ? aws_iam_role.github[0].name : ""
 }
+
+output "oidc_provider_arn" {
+  depends_on  = [aws_iam_openid_connect_provider.github]
+  description = "ARN of the OIDC provider."
+  value       = var.enabled ? aws_iam_openid_connect_provider.github[0].arn : ""
+}


### PR DESCRIPTION
In my case I want to allow additional roles to be assumed. To do that I create a new role and specify in the trust policy that the provider can assume it. For that I need the ARN of the provider :)

I have tested this change by loading my fork of the module and using the new output