### PR TITLE
fix: only use OIDC provider ARN when OIDC provider is created

### DIFF
--- a/outputs.tf
+++ b/outputs.tf
@@ -27,5 +27,5 @@ output "iam_role_name" {
 output "oidc_provider_arn" {
   depends_on  = [aws_iam_openid_connect_provider.github]
   description = "ARN of the OIDC provider."
-  value       = var.enabled ? aws_iam_openid_connect_provider.github[0].arn : ""
+  value       = var.enabled && var.create_oidc_provider ? aws_iam_openid_connect_provider.github[0].arn : ""
 }


### PR DESCRIPTION
This fixes #39.
