### PR TITLE
chore: Set the first automated release version

### DIFF
--- a/.github/release-please-config.json
+++ b/.github/release-please-config.json
@@ -1,5 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",
+  "bootstrap-sha": "6aed749fc1cdbff25a0052eec5ae9a2d584507e9",
+  "initial-version": "1.8.0",
   "packages": {
     ".": {
       "changelog-sections": [


### PR DESCRIPTION
Sets the initial version to 1.8.0 and sets the starting SHA.