### PR TITLE
chore: Update release-please-action organisation

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -65,7 +65,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Prepare a release
-      uses: google-github-actions/release-please-action@v4
+      uses: googleapis/release-please-action@v4
       with:
         config-file: .github/release-please-config.json
         manifest-file: .github/release-please-manifest.json


### PR DESCRIPTION
Google have moved the release-please-action from the google-github-actions organisation to the googleapis organisation.

This GitHub issue comment states that future development will be done in the googleapis organisation.

https://github.com/googleapis/release-please-action/issues/980#issuecomment-2108208115