### PR TITLE
fix: allow wildcard in repo variable

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -74,7 +74,7 @@ variable "github_repositories" {
     // organization/repository format used by GitHub.
     condition = length([
       for repo in var.github_repositories : 1
-      if length(regexall("^[A-Za-z0-9_.-]+?/([A-Za-z0-9_.:/-]+[*]?|\\*)$", repo)) > 0
+      if length(regexall("^[A-Za-z0-9_.-]+?/([A-Za-z0-9_.:/\\-\\*]+)$", repo)) > 0
     ]) == length(var.github_repositories)
     error_message = "Repositories must be specified in the organization/repository format."
   }


### PR DESCRIPTION
Closes #60 

This allows the `github_repositories` variable to have values like:

- `"acme/*:ref:refs/heads/main"`
- `"acme/*:*"`

