### PR TITLE
Swap deprecated inline_policy block for aws_iam_role_policy

### DIFF
--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -31,6 +31,6 @@ data "aws_iam_policy_document" "example" {
   statement {
     actions   = ["s3:GetObject"]
     effect    = "Allow"
-    resources = ["dynamodb:CreateTable"]
+    resources = ["arn:aws:s3:::amzn-s3-demo-bucket/*"]
   }
 }

--- a/examples/complete/variables.tf
+++ b/examples/complete/variables.tf
@@ -40,9 +40,9 @@ variable "enabled" {
 }
 
 variable "enterprise_slug" {
-  default     = false
+  default     = ""
   description = "Enterprise slug for GitHub Enterprise Cloud customers."
-  type        = bool
+  type        = string
 }
 
 variable "force_detach_policies" {

--- a/main.tf
+++ b/main.tf
@@ -32,14 +32,13 @@ resource "aws_iam_role" "github" {
   permissions_boundary  = var.iam_role_permissions_boundary
   tags                  = var.tags
 
-  dynamic "inline_policy" {
-    for_each = var.iam_role_inline_policies
+}
 
-    content {
-      name   = inline_policy.key
-      policy = inline_policy.value
-    }
-  }
+resource "aws_iam_role_policy" "inline_policies" {
+  for_each = { for k, v in var.iam_role_inline_policies : k => v if var.enabled }
+  name     = each.key
+  policy   = each.value
+  role     = aws_iam_role.github[0].id
 }
 
 resource "aws_iam_role_policy_attachment" "admin" {


### PR DESCRIPTION
- Removes the deprecated inline policy block and replaces it with a `aws_iam_role_policy` resource. Not a breaking change
- Fixes a bug in example where enterprise_slug was a bool which created a broken OIDC provider with the URL `https://token.actions.githubusercontent.com/false` 