### PR TITLE
feat: Support non-default AWS partitions

### DIFF
--- a/data.tf
+++ b/data.tf
@@ -33,9 +33,9 @@ data "aws_iam_policy_document" "assume_role" {
     condition {
       test = "StringEquals"
       values = var.additional_audiences != null ? concat(
-        [format("sts.%v", local.dns_suffix)],
+        [local.audience],
         var.additional_audiences,
-      ) : [format("sts.%v", local.dns_suffix)]
+      ) : [local.audience]
       variable = "token.actions.githubusercontent.com:aud"
     }
 

--- a/data.tf
+++ b/data.tf
@@ -31,8 +31,11 @@ data "aws_iam_policy_document" "assume_role" {
     }
 
     condition {
-      test     = "StringEquals"
-      values   = var.additional_audiences != null ? concat(["sts.amazonaws.com"], var.additional_audiences) : ["sts.amazonaws.com"]
+      test = "StringEquals"
+      values = var.additional_audiences != null ? concat(
+        [format("sts.%v", local.dns_suffix)],
+        var.additional_audiences,
+      ) : [format("sts.%v", local.dns_suffix)]
       variable = "token.actions.githubusercontent.com:aud"
     }
 

--- a/main.tf
+++ b/main.tf
@@ -13,13 +13,13 @@
 // limitations under the License.
 
 locals {
+  audience = format("sts.%v", local.dns_suffix)
   github_organizations = toset([
     for repo in var.github_repositories : split("/", repo)[0]
   ])
   dns_suffix        = data.aws_partition.current.dns_suffix
   oidc_provider_arn = var.enabled ? (var.create_oidc_provider ? aws_iam_openid_connect_provider.github[0].arn : data.aws_iam_openid_connect_provider.github[0].arn) : ""
   partition         = data.aws_partition.current.partition
-  sts_domain        = format("sts.%v", local.dns_suffix)
 }
 
 resource "aws_iam_role" "github" {
@@ -69,7 +69,7 @@ resource "aws_iam_openid_connect_provider" "github" {
 
   client_id_list = concat(
     [for org in local.github_organizations : "https://github.com/${org}"],
-    [local.sts_domain],
+    [local.audience],
   )
 
   tags = var.tags

--- a/main.tf
+++ b/main.tf
@@ -16,8 +16,10 @@ locals {
   github_organizations = toset([
     for repo in var.github_repositories : split("/", repo)[0]
   ])
+  dns_suffix        = data.aws_partition.current.dns_suffix
   oidc_provider_arn = var.enabled ? (var.create_oidc_provider ? aws_iam_openid_connect_provider.github[0].arn : data.aws_iam_openid_connect_provider.github[0].arn) : ""
   partition         = data.aws_partition.current.partition
+  sts_domain        = format("sts.%v", local.dns_suffix)
 }
 
 resource "aws_iam_role" "github" {
@@ -67,7 +69,7 @@ resource "aws_iam_openid_connect_provider" "github" {
 
   client_id_list = concat(
     [for org in local.github_organizations : "https://github.com/${org}"],
-    ["sts.amazonaws.com"]
+    [local.sts_domain],
   )
 
   tags = var.tags


### PR DESCRIPTION
Adds support for audiences other than sts.amazonaws.com, this determines the DNS suffix from the partition and builds the URL correctly, so that regions such as China can use the module.