### PR TITLE
chore: Split workflows and simplify testing

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -1,7 +1,7 @@
-name: CI
+name: PR
 
 on:
-  push:
+  pull_request:
     branches:
     - main
     paths-ignore:
@@ -29,18 +29,3 @@ jobs:
       run: terraform fmt -check -recursive
     - name: Validate the configuration
       run: terraform validate
-
-  release:
-    name: Release?
-    needs: [ verify ]
-    permissions:
-      contents: write
-      pull-requests: write
-    runs-on: ubuntu-latest
-    steps:
-    - name: Prepare a release
-      uses: googleapis/release-please-action@v4
-      with:
-        config-file: .github/release-please-config.json
-        manifest-file: .github/release-please-manifest.json
-        token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
The CI workflow has been split into separate CI and PR workflows, and the number of Terraform versions that are tested whenever changes are made to the module has been reduced, Terraform uses semantic versioning so we will only test against the latest major.minor versions.