### PR TITLE
feat: Add a flag to enable/disable role creation

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,23 +83,25 @@ applied, the JWT will contain an updated `iss` claim.
 
 ## Inputs
 
-| Name                            | Description                                                                   | Type           | Default           | Required |
-| ------------------------------- | ----------------------------------------------------------------------------- | -------------- | ----------------- | :------: |
-| additional_audiences            | List of additional OIDC audiences allowed to assume the role.                 | `list(string)` | `null`            |    no    |
-| additional_thumbprints          | A list of additional thumbprints for the OIDC provider.                       | `list(string)` | `[]`              |    no    |
-| attach_read_only_policy         | Flag to enable/disable the attachment of the ReadOnly policy.                 | `bool`         | `false`           |    no    |
-| create_oidc_provider            | Flag to enable/disable the creation of the GitHub OIDC provider.              | `bool`         | `true`            |    no    |
-| dangerously_attach_admin_policy | Flag to enable/disable the attachment of the AdministratorAccess policy.      | `bool`         | `false`           |    no    |
-| enterprise_slug                 | Enterprise slug for GitHub Enterprise Cloud customers.                        | `string`       | `""`              |    no    |
-| force_detach_policies           | Flag to force detachment of policies attached to the IAM role.                | `bool`         | `false`           |    no    |
-| github_repositories             | A list of GitHub organization/repository names authorized to assume the role. | `list(string)` | n/a               |   yes    |
-| iam_role_inline_policies        | Inline policies map with policy name as key and json as value.                | `map(string)`  | `{}`              |    no    |
-| iam_role_name                   | The name of the IAM role to be created and made assumable by GitHub Actions.  | `string`       | `"GitHubActions"` |    no    |
-| iam_role_path                   | The path under which to create IAM role.                                      | `string`       | `"/"`             |    no    |
-| iam_role_permissions_boundary   | The ARN of the permissions boundary to be used by the IAM role.               | `string`       | `""`              |    no    |
-| iam_role_policy_arns            | A list of IAM policy ARNs to attach to the IAM role.                          | `list(string)` | `[]`              |    no    |
-| max_session_duration            | The maximum session duration in seconds.                                      | `number`       | `3600`            |    no    |
-| tags                            | A map of tags to be applied to all applicable resources.                      | `map(string)`  | `{}`              |    no    |
+| Name                            | Description                                                                  | Type           | Default           | Required |
+| ------------------------------- | ---------------------------------------------------------------------------- | -------------- | ----------------- | :------: |
+| additional_audiences            | Additional OIDC audiences allowed to assume the role.                        | `list(string)` | `null`            |    no    |
+| additional_thumbprints          | Additional thumbprints for the OIDC provider.                                | `list(string)` | `[]`              |    no    |
+| attach_read_only_policy         | Enable/disable the attachment of the ReadOnly policy.                        | `bool`         | `false`           |    no    |
+| create_iam_role                 | Enable/disable creation of the IAM role.                                     | `bool`         | `true`            |    no    |
+| create_oidc_provider            | Enable/disable the creation of the GitHub OIDC provider.                     | `bool`         | `true`            |    no    |
+| dangerously_attach_admin_policy | Enable/disable the attachment of the AdministratorAccess policy.             | `bool`         | `false`           |    no    |
+| enabled                         | Enable/disable the creation of resources.                                    | `bool`         | `true`            |    no    |
+| enterprise_slug                 | Enterprise slug for GitHub Enterprise Cloud customers.                       | `string`       | `""`              |    no    |
+| force_detach_policies           | Force detachment of policies attached to the IAM role.                       | `bool`         | `false`           |    no    |
+| github_repositories             | GitHub organization/repository names authorized to assume the role.          | `list(string)` | n/a               |   yes    |
+| iam_role_inline_policies        | Inline policies map with policy name as key and json as value.               | `map(string)`  | `{}`              |    no    |
+| iam_role_name                   | The name of the IAM role to be created and made assumable by GitHub Actions. | `string`       | `"GitHubActions"` |    no    |
+| iam_role_path                   | The path under which to create IAM role.                                     | `string`       | `"/"`             |    no    |
+| iam_role_permissions_boundary   | The ARN of the permissions boundary to be used by the IAM role.              | `string`       | `""`              |    no    |
+| iam_role_policy_arns            | IAM policy ARNs to attach to the IAM role.                                   | `list(string)` | `[]`              |    no    |
+| max_session_duration            | The maximum session duration in seconds.                                     | `number`       | `3600`            |    no    |
+| tags                            | Tags to be applied to all applicable resources.                              | `map(string)`  | `{}`              |    no    |
 
 ## Outputs
 
@@ -108,6 +110,7 @@ applied, the JWT will contain an updated `iss` claim.
 | iam_role_arn      | The ARN of the IAM role.      |
 | iam_role_name     | The name of the IAM role.     |
 | oidc_provider_arn | The ARN of the OIDC provider. |
+| oidc_provider_url | The URL of the OIDC provider. |
 
 <!-- END_TF_DOCS -->
 

--- a/data.tf
+++ b/data.tf
@@ -4,6 +4,8 @@
 data "aws_partition" "this" {}
 
 data "aws_iam_policy_document" "assume_role" {
+  count = var.enabled && var.create_oidc_provider ? 1 : 0
+
   statement {
     actions = ["sts:AssumeRoleWithWebIdentity"]
     effect  = "Allow"

--- a/main.tf
+++ b/main.tf
@@ -12,8 +12,10 @@ locals {
 }
 
 resource "aws_iam_role" "github" {
-  assume_role_policy    = data.aws_iam_policy_document.assume_role.json
-  description           = "Role assumed by the GitHub OIDC provider."
+  count = var.enabled && var.create_iam_role ? 1 : 0
+
+  assume_role_policy    = data.aws_iam_policy_document.assume_role[0].json
+  description           = "Assumed by the GitHub OIDC provider."
   force_detach_policies = var.force_detach_policies
   max_session_duration  = var.max_session_duration
   name                  = var.iam_role_name
@@ -31,24 +33,27 @@ resource "aws_iam_role_policy" "inline_policies" {
 }
 
 resource "aws_iam_role_policy_attachment" "admin" {
-  count = var.dangerously_attach_admin_policy ? 1 : 0
+  count = var.enabled && var.create_iam_role && var.dangerously_attach_admin_policy ? 1 : 0
 
   policy_arn = "arn:${local.partition}:iam::aws:policy/AdministratorAccess"
   role       = aws_iam_role.github.id
 }
 
 resource "aws_iam_role_policy_attachment" "read_only" {
-  count = var.attach_read_only_policy ? 1 : 0
+  count = var.enabled && var.create_iam_role && var.attach_read_only_policy ? 1 : 0
 
   policy_arn = "arn:${local.partition}:iam::aws:policy/ReadOnlyAccess"
   role       = aws_iam_role.github.id
 }
 
 resource "aws_iam_role_policy_attachment" "custom" {
-  count = length(var.iam_role_policy_arns)
+  count = var.enabled && var.create_iam_role ? length(var.iam_role_policy_arns) : 0
 
-  policy_arn = var.iam_role_policy_arns[count.index]
-  role       = aws_iam_role.github.id
+  role = aws_iam_role.github[0].id
+  policy_arn = format(
+    "arn:%v:iam::aws:policy/AdministratorAccess",
+    local.partition,
+  )
 }
 
 resource "aws_iam_openid_connect_provider" "github" {

--- a/main.tf
+++ b/main.tf
@@ -29,21 +29,21 @@ resource "aws_iam_role_policy" "inline_policies" {
 
   name   = each.key
   policy = each.value
-  role   = aws_iam_role.github.id
+  role   = aws_iam_role.github[0].id
 }
 
 resource "aws_iam_role_policy_attachment" "admin" {
   count = var.enabled && var.create_iam_role && var.dangerously_attach_admin_policy ? 1 : 0
 
   policy_arn = "arn:${local.partition}:iam::aws:policy/AdministratorAccess"
-  role       = aws_iam_role.github.id
+  role       = aws_iam_role.github[0].id
 }
 
 resource "aws_iam_role_policy_attachment" "read_only" {
   count = var.enabled && var.create_iam_role && var.attach_read_only_policy ? 1 : 0
 
   policy_arn = "arn:${local.partition}:iam::aws:policy/ReadOnlyAccess"
-  role       = aws_iam_role.github.id
+  role       = aws_iam_role.github[0].id
 }
 
 resource "aws_iam_role_policy_attachment" "custom" {

--- a/outputs.tf
+++ b/outputs.tf
@@ -3,12 +3,12 @@
 
 output "iam_role_arn" {
   description = "The ARN of the IAM role."
-  value       = aws_iam_role.github.arn
+  value       = var.enabled && var.create_iam_role ? aws_iam_role.github[0].arn : ""
 }
 
 output "iam_role_name" {
   description = "The name of the IAM role."
-  value       = aws_iam_role.github.name
+  value       = var.enabled && var.create_iam_role ? aws_iam_role.github[0].name : ""
 }
 
 output "oidc_provider_arn" {

--- a/variables.tf
+++ b/variables.tf
@@ -3,13 +3,13 @@
 
 variable "additional_audiences" {
   default     = null
-  description = "List of additional OIDC audiences allowed to assume the role."
+  description = "Additional OIDC audiences allowed to assume the role."
   type        = list(string)
 }
 
 variable "additional_thumbprints" {
   default     = []
-  description = "A list of additional thumbprints for the OIDC provider."
+  description = "Additional thumbprints for the OIDC provider."
   type        = list(string)
 
   validation {
@@ -20,25 +20,31 @@ variable "additional_thumbprints" {
 
 variable "attach_read_only_policy" {
   default     = false
-  description = "Flag to enable/disable the attachment of the ReadOnly policy."
+  description = "Enable/disable the attachment of the ReadOnly policy."
   type        = bool
 }
 
 variable "create_oidc_provider" {
   default     = true
-  description = "Flag to enable/disable the creation of the GitHub OIDC provider."
+  description = "Enable/disable the creation of the GitHub OIDC provider."
   type        = bool
 }
 
 variable "create_iam_role" {
   default     = true
-  description = ""
+  description = "Enable/disable creation of the IAM role."
   type        = bool
 }
 
 variable "dangerously_attach_admin_policy" {
   default     = false
-  description = "Flag to enable/disable the attachment of the AdministratorAccess policy."
+  description = "Enable/disable the attachment of the AdministratorAccess policy."
+  type        = bool
+}
+
+variable "enabled" {
+  default     = true
+  description = "Enable/disable the creation of resources."
   type        = bool
 }
 
@@ -50,12 +56,12 @@ variable "enterprise_slug" {
 
 variable "force_detach_policies" {
   default     = false
-  description = "Flag to force detachment of policies attached to the IAM role."
+  description = "Force detachment of policies attached to the IAM role."
   type        = bool
 }
 
 variable "github_repositories" {
-  description = "A list of GitHub organization/repository names authorized to assume the role."
+  description = "GitHub organization/repository names authorized to assume the role."
   type        = list(string)
 
   validation {
@@ -89,7 +95,7 @@ variable "iam_role_permissions_boundary" {
 
 variable "iam_role_policy_arns" {
   default     = []
-  description = "A list of IAM policy ARNs to attach to the IAM role."
+  description = "IAM policy ARNs to attach to the IAM role."
   type        = list(string)
 }
 
@@ -112,6 +118,6 @@ variable "max_session_duration" {
 
 variable "tags" {
   default     = {}
-  description = "A map of tags to be applied to all applicable resources."
+  description = "Tags to be applied to all applicable resources."
   type        = map(string)
 }

--- a/variables.tf
+++ b/variables.tf
@@ -30,6 +30,12 @@ variable "create_oidc_provider" {
   type        = bool
 }
 
+variable "create_iam_role" {
+  default     = true
+  description = ""
+  type        = bool
+}
+
 variable "dangerously_attach_admin_policy" {
   default     = false
   description = "Flag to enable/disable the attachment of the AdministratorAccess policy."


### PR DESCRIPTION
The module previously created a role automatically, and allowed managed policies and inline policies to be attached to the role, this works well for simple setups but makes it difficult to do multiple account/multiple role OIDC configurations.