### PR TITLE
chore!: Rename the attach_admin_policy variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,24 +83,24 @@ applied, the JWT will contain an updated `iss` claim.
 
 ## Inputs
 
-| Name                          | Description                                                                 | Type           | Default    | Required |
-| ----------------------------- | --------------------------------------------------------------------------- | -------------- | ---------- | :------: |
-| additional_audiences          | List of additional OIDC audiences allowed to assume the role.               | `list(string)` | `null`     |    no    |
-| additional_thumbprints        | List of additional thumbprints for the OIDC provider.                       | `list(string)` | `[]`       |    no    |
-| attach_admin_policy           | Flag to enable/disable the attachment of the AdministratorAccess policy.    | `bool`         | `false`    |    no    |
-| attach_read_only_policy       | Flag to enable/disable the attachment of the ReadOnly policy.               | `bool`         | `false`    |    no    |
-| create_oidc_provider          | Flag to enable/disable the creation of the GitHub OIDC provider.            | `bool`         | `true`     |    no    |
-| enabled                       | Flag to enable/disable the creation of resources.                           | `bool`         | `true`     |    no    |
-| enterprise_slug               | Enterprise slug for GitHub Enterprise Cloud customers.                      | `string`       | `""`       |    no    |
-| force_detach_policies         | Flag to force detachment of policies attached to the IAM role.              | `bool`         | `false`    |    no    |
-| github_repositories           | List of GitHub organization/repository names authorized to assume the role. | `list(string)` | n/a        |   yes    |
-| iam_role_inline_policies      | Inline policies map with policy name as key and json as value.              | `map(string)`  | `{}`       |    no    |
-| iam_role_name                 | Name of the IAM role to be created. This will be assumable by GitHub.       | `string`       | `"github"` |    no    |
-| iam_role_path                 | Path under which to create IAM role.                                        | `string`       | `"/"`      |    no    |
-| iam_role_permissions_boundary | ARN of the permissions boundary to be used by the IAM role.                 | `string`       | `""`       |    no    |
-| iam_role_policy_arns          | List of IAM policy ARNs to attach to the IAM role.                          | `list(string)` | `[]`       |    no    |
-| max_session_duration          | Maximum session duration in seconds.                                        | `number`       | `3600`     |    no    |
-| tags                          | Map of tags to be applied to all resources.                                 | `map(string)`  | `{}`       |    no    |
+| Name                            | Description                                                                 | Type           | Default    | Required |
+| ------------------------------- | --------------------------------------------------------------------------- | -------------- | ---------- | :------: |
+| additional_audiences            | List of additional OIDC audiences allowed to assume the role.               | `list(string)` | `null`     |    no    |
+| additional_thumbprints          | List of additional thumbprints for the OIDC provider.                       | `list(string)` | `[]`       |    no    |
+| attach_read_only_policy         | Flag to enable/disable the attachment of the ReadOnly policy.               | `bool`         | `false`    |    no    |
+| create_oidc_provider            | Flag to enable/disable the creation of the GitHub OIDC provider.            | `bool`         | `true`     |    no    |
+| dangerously_attach_admin_policy | Flag to enable/disable the attachment of the AdministratorAccess policy.    | `bool`         | `false`    |    no    |
+| enabled                         | Flag to enable/disable the creation of resources.                           | `bool`         | `true`     |    no    |
+| enterprise_slug                 | Enterprise slug for GitHub Enterprise Cloud customers.                      | `string`       | `""`       |    no    |
+| force_detach_policies           | Flag to force detachment of policies attached to the IAM role.              | `bool`         | `false`    |    no    |
+| github_repositories             | List of GitHub organization/repository names authorized to assume the role. | `list(string)` | n/a        |   yes    |
+| iam_role_inline_policies        | Inline policies map with policy name as key and json as value.              | `map(string)`  | `{}`       |    no    |
+| iam_role_name                   | Name of the IAM role to be created. This will be assumable by GitHub.       | `string`       | `"github"` |    no    |
+| iam_role_path                   | Path under which to create IAM role.                                        | `string`       | `"/"`      |    no    |
+| iam_role_permissions_boundary   | ARN of the permissions boundary to be used by the IAM role.                 | `string`       | `""`       |    no    |
+| iam_role_policy_arns            | List of IAM policy ARNs to attach to the IAM role.                          | `list(string)` | `[]`       |    no    |
+| max_session_duration            | Maximum session duration in seconds.                                        | `number`       | `3600`     |    no    |
+| tags                            | Map of tags to be applied to all resources.                                 | `map(string)`  | `{}`       |    no    |
 
 ## Outputs
 

--- a/main.tf
+++ b/main.tf
@@ -44,7 +44,7 @@ resource "aws_iam_role_policy" "inline_policies" {
 }
 
 resource "aws_iam_role_policy_attachment" "admin" {
-  count = var.enabled && var.attach_admin_policy ? 1 : 0
+  count = var.enabled && var.dangerously_attach_admin_policy ? 1 : 0
 
   policy_arn = "arn:${local.partition}:iam::aws:policy/AdministratorAccess"
   role       = aws_iam_role.github[0].id

--- a/variables.tf
+++ b/variables.tf
@@ -29,12 +29,6 @@ variable "additional_thumbprints" {
   }
 }
 
-variable "attach_admin_policy" {
-  default     = false
-  description = "Flag to enable/disable the attachment of the AdministratorAccess policy."
-  type        = bool
-}
-
 variable "attach_read_only_policy" {
   default     = false
   description = "Flag to enable/disable the attachment of the ReadOnly policy."
@@ -44,6 +38,12 @@ variable "attach_read_only_policy" {
 variable "create_oidc_provider" {
   default     = true
   description = "Flag to enable/disable the creation of the GitHub OIDC provider."
+  type        = bool
+}
+
+variable "dangerously_attach_admin_policy" {
+  default     = false
+  description = "Flag to enable/disable the attachment of the AdministratorAccess policy."
   type        = bool
 }
 


### PR DESCRIPTION
Renames the `attach_admin_policy` variable to
`dangerously_attach_admin_policy` to make it more obvious that this should be used cautiously.