### PR TITLE
chore!: Increase the minimum required versions

### DIFF
--- a/versions.tf
+++ b/versions.tf
@@ -16,14 +16,14 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 4.0"
+      version = ">= 5.0"
     }
 
     tls = {
       source  = "hashicorp/tls"
-      version = ">= 3.0"
+      version = ">= 4.0"
     }
   }
 
-  required_version = "~> 1.0"
+  required_version = "~> 1.10"
 }


### PR DESCRIPTION
Bumps the minimum required version for Terraform and both the AWS and TLS providers.