### PR TITLE
chore: Automatically bump README.md version number

### DIFF
--- a/.github/release-please-config.json
+++ b/.github/release-please-config.json
@@ -28,7 +28,14 @@
       "prerelease": false,
       "pull-request-header": "🤖 I have created a release",
       "pull-request-title-pattern": "chore: Release v${version}",
-      "release-type": "terraform-module"
+      "release-type": "terraform-module",
+      "extra-files": [
+        {
+          "glob": false,
+          "path": "README.md",
+          "type": "generic"
+        }
+      ]
     }
   }
 }


### PR DESCRIPTION
Automatically bump the version number in the README inline with releases.