### PR TITLE
fix: Reduce the minimum Terraform version required

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -35,7 +35,7 @@ jobs:
     - name: Setup Terraform
       uses: hashicorp/setup-terraform@v3
       with:
-        terraform_version: "1.12"
+        terraform_version: "1.13"
     - name: Initialise with no backend
       run: terraform init -backend=false
     - name: Check formatting

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ between GitHub Actions workflows and AWS resources.
 
 ### Requirements
 
-- [Terraform] 1.12+
+- [Terraform] 1.0+
 
 ### Installation and usage
 

--- a/examples/basic/versions.tf
+++ b/examples/basic/versions.tf
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: MIT
 
 terraform {
-  required_version = "~> 1.12"
+  required_version = "~> 1.0"
 
   required_providers {
     aws = {

--- a/examples/multiple-roles/versions.tf
+++ b/examples/multiple-roles/versions.tf
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: MIT
 
 terraform {
-  required_version = "~> 1.12"
+  required_version = "~> 1.0"
 
   required_providers {
     aws = {

--- a/versions.tf
+++ b/versions.tf
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: MIT
 
 terraform {
-  required_version = "~> 1.12"
+  required_version = "~> 1.0"
 
   required_providers {
     aws = {


### PR DESCRIPTION
Reduces the minimum required Terraform version to 1.0, testing requires a later version so the workflow versions have not been reduced.

Fixes #89 