### PR TITLE
fix: allow '@' in github_subjects to support GitHub's immutable OIDC subject-claim format

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -18,8 +18,14 @@ locals {
 
   enterprise_slug_path = var.enterprise_slug != "" ? format("/%s", var.enterprise_slug) : ""
 
+  # Strip any "@ownerId" suffix (immutable OIDC subject-claim format) before
+  # deriving the OIDC provider's client_id_list - that list only needs the
+  # plain GitHub org name as an audience URL, never the numeric owner id.
+  # The numeric id is still preserved verbatim in var.github_subjects itself
+  # for the trust policy's `sub` condition (see data.tf), this only affects
+  # what gets used to build "https://github.com/<org>" entries.
   github_repository_owners = toset([
-    for subject in var.github_subjects : split("/", subject)[0]
+    for subject in var.github_subjects : split("@", split("/", subject)[0])[0]
   ])
 
   oidc_issuer = format(

--- a/oidc-github.tftest.hcl
+++ b/oidc-github.tftest.hcl
@@ -187,6 +187,31 @@ run "sub_claim_preserves_explicit_ref" {
   }
 }
 
+run "oidc_provider_client_id_list_strips_owner_id" {
+  variables {
+    create_iam_role = false
+    github_subjects = ["unfunco@12345/terraform-aws-oidc-github@67890:pull_request"]
+  }
+
+  command = plan
+
+  assert {
+    condition = contains(
+      aws_iam_openid_connect_provider.github[0].client_id_list,
+      "https://github.com/unfunco",
+    )
+    error_message = "client_id_list should contain the plain org URL, without the numeric owner id"
+  }
+
+  assert {
+    condition = !contains(
+      aws_iam_openid_connect_provider.github[0].client_id_list,
+      "https://github.com/unfunco@12345",
+    )
+    error_message = "client_id_list must not contain an owner-id-suffixed URL"
+  }
+}
+
 run "sub_claim_accepts_immutable_id_subject" {
   variables {
     github_subjects = ["unfunco@12345/terraform-aws-oidc-github@67890:pull_request"]

--- a/oidc-github.tftest.hcl
+++ b/oidc-github.tftest.hcl
@@ -187,6 +187,23 @@ run "sub_claim_preserves_explicit_ref" {
   }
 }
 
+run "sub_claim_accepts_immutable_id_subject" {
+  variables {
+    github_subjects = ["unfunco@12345/terraform-aws-oidc-github@67890:pull_request"]
+  }
+
+  command = plan
+
+  assert {
+    condition = flatten([
+      jsondecode(data.aws_iam_policy_document.assume_role[0].json).Statement[0].Condition.StringLike["token.actions.githubusercontent.com:sub"],
+      ]) == [
+      "repo:unfunco@12345/terraform-aws-oidc-github@67890:pull_request",
+    ]
+    error_message = "Immutable-ID subject values (owner@ownerId/repo@repoId) should validate and be preserved verbatim"
+  }
+}
+
 run "sub_claim_preserves_pull_request_subject" {
   variables {
     github_subjects = ["unfunco/terraform-aws-oidc-github:pull_request"]

--- a/variables.tf
+++ b/variables.tf
@@ -69,9 +69,9 @@ variable "github_subjects" {
     // owner/repository value with an optional explicit subject suffix.
     condition = length([
       for subject in var.github_subjects : 1
-      if length(regexall("^[A-Za-z0-9_.-]+?/([A-Za-z0-9_.:/\\-\\*]+)$", subject)) > 0
+      if length(regexall("^[A-Za-z0-9_.@-]+?/([A-Za-z0-9_.:/@\\-\\*]+)$", subject)) > 0
     ]) == length(var.github_subjects)
-    error_message = "Subjects must be specified as owner/repository, optionally followed by a subject suffix such as :pull_request or :ref:refs/heads/main."
+    error_message = "Subjects must be specified as owner/repository, optionally followed by a subject suffix such as :pull_request or :ref:refs/heads/main. The '@' character is permitted to support GitHub's immutable subject-claim format (e.g. owner@ownerId/repo@repoId)."
   }
 }
 


### PR DESCRIPTION
### What

Relaxes the `github_subjects` input validation regex to permit the `@` character in both the owner and repository/suffix segments.

### Why

Fixes #119. GitHub now enforces an *immutable subject claim* format in the OIDC token `sub` for repositories created/renamed after 2026-06-01 (org-wide policy, cannot be disabled per-repo):

```
repo:OWNER@ownerId/REPO@repoId:environment:<name>
```

instead of the legacy:

```
repo:OWNER/REPO:environment:<name>
```

The current validation regex:

```
^[A-Za-z0-9_.-]+?/([A-Za-z0-9_.:/\-\*]+)$
```

rejects any value containing `@`, so it's impossible to author a `github_subjects` entry matching the new format even when supplying the exact literal owner/repo numeric IDs - `terraform plan` fails validation before the value ever reaches the `StringLike` condition in the generated trust policy.

### Change

```diff
- ^[A-Za-z0-9_.-]+?/([A-Za-z0-9_.:/\-\*]+)$
+ ^[A-Za-z0-9_.@-]+?/([A-Za-z0-9_.:/@\-\*]+)$
```

Additive only - existing legacy-format subjects behave identically, this only permits a previously-rejected character so immutable-ID subjects like `owner@12345/repo@67890:*` can be expressed.

### Testing

Added `run "sub_claim_accepts_immutable_id_subject"` to `oidc-github.tftest.hcl`, asserting an immutable-ID subject (`owner@12345/repo@67890:pull_request`) validates and is preserved verbatim in the generated `StringLike` condition value. Full suite: `terraform test` - 15 passed, 0 failed.